### PR TITLE
fix: update scripts and docs to solve Jupyter kernel selection issue

### DIFF
--- a/.devcontainer/install-jupyter-extension.sh
+++ b/.devcontainer/install-jupyter-extension.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_VERSION="${1:-2025.9.2025092201}"
+ENGINE_MIN="${2:-1.104.0}"
+
+if ! command -v code >/dev/null 2>&1; then
+  echo "VS Code CLI (code) is not available; skipping Jupyter extension install" >&2
+  exit 0
+fi
+
+if code --list-extensions --show-versions | grep -q "ms-toolsai.jupyter@${TARGET_VERSION}"; then
+  echo "Jupyter extension ${TARGET_VERSION} already installed"
+  exit 0
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+VSIX_GZ="${TMP_DIR}/jupyter.vsix.gz"
+VSIX="${TMP_DIR}/jupyter.vsix"
+PATCHED="${TMP_DIR}/jupyter_patched.vsix"
+
+DOWNLOAD_URL="https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ms-toolsai/vsextensions/jupyter/${TARGET_VERSION}/vspackage"
+
+echo "Downloading Jupyter extension ${TARGET_VERSION} from ${DOWNLOAD_URL}" >&2
+curl -sSL "${DOWNLOAD_URL}" -o "${VSIX_GZ}"
+
+echo "Decompressing VSIX package" >&2
+gzip -dc "${VSIX_GZ}" > "${VSIX}"
+
+TMP_DIR="${TMP_DIR}" ENGINE_MIN="${ENGINE_MIN}" VSIX="${VSIX}" PATCHED="${PATCHED}" python - <<'PY'
+import json
+import os
+import pathlib
+import shutil
+import tempfile
+import zipfile
+
+vsix_path = pathlib.Path(os.environ["VSIX"])
+patched_path = pathlib.Path(os.environ["PATCHED"])
+engine_min = os.environ["ENGINE_MIN"]
+
+work_dir = pathlib.Path(tempfile.mkdtemp())
+try:
+    with zipfile.ZipFile(vsix_path) as zf:
+        zf.extractall(work_dir)
+
+    package_json = work_dir / "extension" / "package.json"
+    data = json.loads(package_json.read_text())
+    data["engines"]["vscode"] = f">={engine_min}"
+    package_json.write_text(json.dumps(data, indent=2))
+
+    with zipfile.ZipFile(patched_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for file_path in work_dir.rglob("*"):
+            if file_path.is_file():
+                zf.write(file_path, file_path.relative_to(work_dir))
+finally:
+    shutil.rmtree(work_dir)
+PY
+
+echo "Installing patched Jupyter extension" >&2
+code --install-extension "${PATCHED}" --force > /dev/null
+
+code --list-extensions --show-versions | grep -i jupyter

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,2 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
 uv sync
 python -m ipykernel install --user --name=mlfundamentals-env --display-name "ML-Fundamentals-env"
+
+# Ensure a compatible Jupyter extension is installed for the current VS Code version
+"$(dirname "${BASH_SOURCE[0]}")/install-jupyter-extension.sh"

--- a/docs/env-setup-codespaces.md
+++ b/docs/env-setup-codespaces.md
@@ -18,7 +18,7 @@ Go to the repository and select `Code -> Codespaces (tab)`.
 
 ### 2. Wait for the Codespace to be created
 
-It may take a couple of minutes for the Codespace environment to be created the first time, after which you will see something like the UI below. The Codespace comes with a Devcontainer, and if you look closely in the terminal, you'll notice a post-create script running - it's installing all Python dependencies within a virtual environment.
+It may take a couple of minutes for the Codespace environment to be created the first time, after which you will see something like the UI below. The Codespace comes with a Devcontainer, and if you look closely in the terminal, you'll notice a post-create script running - it's installing all Python dependencies within a virtual environment **and patching the Jupyter VS Code extension so that the kernel picker works out of the box**.
 
 ![Created and installing](images/created_codespace.png)
 
@@ -32,9 +32,11 @@ Each time you open a notebook for the first time, click "select kernel" in the t
 
 ![Python Environments](images/kernel_selection.png)
 
-Go with the recommended virtual env (located within your repo's working directory):
+Go with the recommended virtual env (located within your repo's working directory). It will appear as **ML-Fundamentals-env**:
 
 
 ![Venv](images/kernel_recommended.png)
 
 You should now be ready to go.  Try running a cell to ensure the everything is running fine!
+
+> **Tip:** If the kernel picker ever keeps spinning, run `Developer: Reload Window` once. The `.devcontainer/install-jupyter-extension.sh` script is idempotent, so rerunning `bash .devcontainer/install-jupyter-extension.sh` inside the Codespace will reapply the compatibility patch if needed.

--- a/docs/env-setup-local.md
+++ b/docs/env-setup-local.md
@@ -21,6 +21,9 @@ Use one of the following options to create your virtualenv and install dependenc
 - You can then activate the virtualenv.
   - On Windows - `.venv\Scripts\activate`
   - On macOS/Linux: `source .venv/bin/activate`
+- Register the kernel for Jupyter notebooks:
+  - On Windows: `.venv\Scripts\python.exe -m ipykernel install --user --name=ml-fundamentals --display-name="Python 3.11 (ml-fundamentals)"`
+  - On macOS/Linux: `python -m ipykernel install --user --name=ml-fundamentals --display-name="Python 3.11 (ml-fundamentals)"`
 
 After activation, you should see the virtual environment name in your terminal prompt.
 
@@ -39,6 +42,10 @@ You can either:
 - activate this virtualenv with `poetry shell` OR
 - execute commands using `poetry run ...` instead
 
+After setting up with Poetry, register the kernel for Jupyter notebooks:
+- If using `poetry shell`: `python -m ipykernel install --user --name=ml-fundamentals --display-name="Python 3.11 (ml-fundamentals)"`
+- If not activated: `poetry run python -m ipykernel install --user --name=ml-fundamentals --display-name="Python 3.11 (ml-fundamentals)"`
+
 <br>
 
 ### Option 3 - using the basic venv module
@@ -51,10 +58,15 @@ python -m venv .venv
 source .venv/bin/activate
 
 pip install -r requirements.txt
+
+# Register the kernel for Jupyter notebooks
+python -m ipykernel install --user --name=ml-fundamentals --display-name="Python 3.11 (ml-fundamentals)"
 ```
 
 <br>
 
 ## Use the notebooks
+
+After completing the setup above, the kernel "Python 3.11 (ml-fundamentals)" will be available in VS Code's kernel picker. 
 
 You're now ready to [run the notebooks in VS Code](using-notebooks-in-vs-code.md).

--- a/docs/env-setup-local.md
+++ b/docs/env-setup-local.md
@@ -25,7 +25,7 @@ Use one of the following options to create your virtualenv and install dependenc
   - On Windows: `.venv\Scripts\python.exe -m ipykernel install --user --name=ml-fundamentals --display-name="Python 3.11 (ml-fundamentals)"`
   - On macOS/Linux: `python -m ipykernel install --user --name=ml-fundamentals --display-name="Python 3.11 (ml-fundamentals)"`
 
-After activation, you should see the virtual environment name in your terminal prompt.
+After activation, you should see the virtual environment name in your terminal prompt. Leave the terminal open—we'll reuse it to patch the VS Code Jupyter extension in a later step.
 
 <br>
 
@@ -68,5 +68,33 @@ python -m ipykernel install --user --name=ml-fundamentals --display-name="Python
 ## Use the notebooks
 
 After completing the setup above, the kernel "Python 3.11 (ml-fundamentals)" will be available in VS Code's kernel picker. 
+
+You're now ready to [run the notebooks in VS Code](using-notebooks-in-vs-code.md).
+
+<br>
+
+## Patch the Jupyter VS Code extension
+
+If the kernel picker in VS Code spins forever, you're likely hitting the same incompatibility that affects Codespaces: the legacy Jupyter extension (2023.8.x) bundled with the editor can't run on VS Code 1.104.x. This repo includes a helper script that downloads the latest extension, widens its engine constraint, and installs it for you.
+
+Run the script after you create and activate your virtual environment (choose the command that matches your shell):
+
+```bash
+# macOS / Linux / Git Bash / WSL
+bash .devcontainer/install-jupyter-extension.sh
+```
+
+```powershell
+# Windows PowerShell (requires Git Bash in PATH)
+bash .devcontainer/install-jupyter-extension.sh
+```
+
+When the script finishes, reload VS Code once (`Developer: Reload Window`). You can verify the installation with:
+
+```bash
+code --list-extensions --show-versions
+```
+
+You should see `ms-toolsai.jupyter@2025.9.2025092201` in the output. If you ever hit the spinning picker again, simply rerun the script—it’s idempotent.
 
 You're now ready to [run the notebooks in VS Code](using-notebooks-in-vs-code.md).

--- a/docs/using-notebooks-in-vs-code.md
+++ b/docs/using-notebooks-in-vs-code.md
@@ -15,7 +15,7 @@ You should see a “Select Kernel” prompt at the top right.  Choose "Python En
 
 ![Select kernel](images/kernel_selection.png)
 
-Go with the recommended virtual env (located within your repo's working directory):
+Go with the recommended virtual env (located within your repo's working directory). In Codespaces this appears as **Python 3.11 (ML-Fundamentals-env)**, created automatically by the devcontainer setup:
 
 ![Venv](images/kernel_recommended.png)
 
@@ -38,6 +38,17 @@ Where '->' indicates the shortcut follows the Esc key.
 
 <br>
 
-## Trouble shooting
+## Troubleshooting
 
-Debugging the extensions in VS Code by running `code —list-extensions` in the terminal.
+- If the kernel picker keeps loading forever, it's usually because the stock Jupyter extension (2023.8.x) bundled with VS Code isn't compatible with the 1.104.x editor build the repo uses. The devcontainer’s post-create script already patches the extension, but if you’re working locally run:
+
+	```bash
+	bash .devcontainer/install-jupyter-extension.sh
+	```
+
+	Then reload VS Code once (`Developer: Reload Window`). You should see `ms-toolsai.jupyter@2025.9.2025092201` when you run `code --list-extensions --show-versions`.
+- To inspect all installed extensions, run:
+
+	```bash
+	code --list-extensions --show-versions
+	```


### PR DESCRIPTION
The old Jupyter extension that ships with the container was trying to call `vscNotebook.onDidChangeNotebookCellExecutionState`, which isn’t available in that build of VS Code (1.104.x). That mismatch kept the extension from activating, so the kernel picker never finished loading. Installing the newer Jupyter build (2025.9) fixes the API mismatch, but the Marketplace package declares a stricter engine requirement (^1.105.0). By patching the extension so it runs on 1.104.x and making the patch part of the devcontainer setup fixes the hanging issue.